### PR TITLE
Revert footer year back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This reverts the earlier fix that updated the footer year from 2022 to 2023.